### PR TITLE
RSPY-722 - Resolve conflicting json schema validation

### DIFF
--- a/config/openapi_templates/yaml/inputValueNoObject.yaml
+++ b/config/openapi_templates/yaml/inputValueNoObject.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oneOf:
+anyOf:
   - type: string
   - type: number
   - type: integer


### PR DESCRIPTION
silly behaviour where some particular strings like "collection10" are both considered normal strings and binary strings (don't understand why). So I switched a "oneOf" to a "anyOf" (change already done in upstream repository, as a matter of fact).

All pull requests as we have these json schemas across multiple repositories:
https://github.com/RS-PYTHON/rs-client-libraries/pull/97
https://github.com/RS-PYTHON/rs-dpr-service/pull/18
https://github.com/RS-PYTHON/rs-server/pull/1403