### PR TITLE
Update S3_L0 and S1_L0 tasktable

### DIFF
--- a/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
@@ -3,7 +3,7 @@
     "tasktable": {
         "name": "s1-l0",
         "version": 1.0,
-        "specification_version": "1.0_draftE",
+        "specification_version": "1.0_draftG",
         "update_datetime": "2025-10-03T11:00:00Z",
         "configuration_path": {}
     },
@@ -47,10 +47,28 @@
             ],
             "output_products": [
                 {
-                    "name": "output_folder",
+                    "name": "S01SARRAW",
                     "mode": "always",
-                    "mandatory": true,
-                    "regex": ".*"
+                    "mandatory": false,
+                    "regex": "^datatakeid_.*"
+                },
+                {
+                    "name": "S01GPSRAW",
+                    "mode": "always",
+                    "mandatory": false,
+                    "regex": "^gps$"
+                },
+                {
+                    "name": "S01HKMRAW",
+                    "mode": "always",
+                    "mandatory": false,
+                    "regex": "^hktm$"
+                },
+                {
+                    "name": "S01AISRAW",
+                    "mode": "always",
+                    "mandatory": false,
+                    "regex": "^ais_.*"
                 }
             ]
         }
@@ -96,7 +114,7 @@
                             "product_type": "MPL_ORBPRE",
                             "start_datetime": "{external_variable.start_datetime}",
                             "end_datetime": "{external_variable.end_datetime}",
-                            "dTa": 7200,
+                            "dTa": 345600,
                             "dTb": 0
                         }
                     }
@@ -104,7 +122,25 @@
             ]
         },
         {
-            "name": "output_folder",
+            "name": "S01SARRAW",
+            "type": "folder",
+            "store_type": "zarr",
+            "opening_mode": "CREATE_OVERWRITE"
+        },
+        {
+            "name": "S01GPSRAW",
+            "type": "folder",
+            "store_type": "zarr",
+            "opening_mode": "CREATE_OVERWRITE"
+        },
+        {
+            "name": "S01HKMRAW",
+            "type": "folder",
+            "store_type": "zarr",
+            "opening_mode": "CREATE_OVERWRITE"
+        },
+        {
+            "name": "S01AISRAW",
             "type": "folder",
             "store_type": "zarr",
             "opening_mode": "CREATE_OVERWRITE"
@@ -122,57 +158,66 @@
             ],
             "stac": {
                 "filter": {
-                "op": "and",
-                "args": [
-                    {
-                    "op": "=",
+                    "op": "and",
                     "args": [
                         {
-                        "property": "product:type"
-                        },
-                        "{product_type}"
-                    ]
-                    },
-                    {
-                    "op": "t_intersects",
-                    "args": [
-                        {
-                        "interval": [
-                            {
-                            "property": "start_datetime"
-                            },
-                            {
-                            "property": "end_datetime"
-                            }
-                        ]
+                            "op": "=",
+                            "args": [
+                                {
+                                    "property": "product:type"
+                                },
+                                "{product_type}"
+                            ]
                         },
                         {
-                        "interval": [
-                            {
-                            "op": "-",
+                            "op": "=",
                             "args": [
-                                "{start_datetime}",
-                                "{dTa}"
+                                {
+                                    "property": "platform"
+                                },
+                                "sentinel-1a"
                             ]
-                            },
-                            {
-                            "op": "+",
+                        },
+                        {
+                            "op": "t_contains",
                             "args": [
-                                "{end_datetime}",
-                                "{dTb}"
+                                {
+                                    "interval": [
+                                        {
+                                            "property": "start_datetime"
+                                        },
+                                        {
+                                            "property": "end_datetime"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "interval": [
+                                        {
+                                            "op": "-",
+                                            "args": [
+                                                "{start_datetime}",
+                                                "{dTa}"
+                                            ]
+                                        },
+                                        {
+                                            "op": "+",
+                                            "args": [
+                                                "{end_datetime}",
+                                                "{dTb}"
+                                            ]
+                                        }
+                                    ]
+                                }
                             ]
-                            }
-                        ]
                         }
                     ]
-                    }
-                ]
                 },
                 "sortby": [
-                {
-                    "field": "created",
-                    "direction": "desc"
-                }
+                    {
+                        "field": "created",
+                        "direction": "desc"
+                    }
                 ],
                 "limit": 1
             }
@@ -190,7 +235,10 @@
                         "S1CADUS": "pipeline_input"
                     },
                     "output_products": {
-                        "output_folder": "pipeline_output"
+                        "S01SARRAW": "pipeline_output",
+                        "S01GPSRAW": "pipeline_output",
+                        "S01HKMRAW": "pipeline_output",
+                        "S01AISRAW": "pipeline_output"
                     }
                 }
             ]

--- a/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
@@ -9,7 +9,8 @@
   },
   "external_variables": [
     "start_datetime",
-    "end_datetime"
+    "end_datetime",
+    "satellite"
   ],
   "units": [
     {
@@ -82,6 +83,7 @@
               "product_type": "AX___OSF_AX",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
+	      "satellite": "{external_variable.satellite}",
               "dTa": 6000,
               "dTb": 6000
             }
@@ -103,6 +105,7 @@
               "product_type": "AX___FRO_AX",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
+	      "satellite": "{external_variable.satellite}",
               "dTa": 7000,
               "dTb": 7000
             }
@@ -130,6 +133,7 @@
         "product_type",
         "start_datetime",
         "end_datetime",
+	"satellite",
         "dTa",
         "dTb"
       ],
@@ -147,7 +151,16 @@
               ]
             },
             {
-              "op": "t_intersects",
+              "op": "=",
+              "args": [
+                 {
+                  "property": "platform"
+                 },
+                 "sentinel-3a"
+               ]
+            },
+            {
+              "op": "t_contains",
               "args": [
                 {
                   "interval": [


### PR DESCRIPTION
Hereafter update

-  S1_L0

t_contains instead of t_intersect for LatestValCover rules
Currently only 4 types should be use: HKTM GPS AIS SAR 
Add satellite search for auxiliary data (forced to s1a  until following issue was fixed [RSPY-988](https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-988))

-  S3_L0

t_contains instead of t_intersect for LatestValCover rules
Add satellite search for auxiliary data (forced to s3a until following issue was fixed [RSPY-988](https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-988))
