### PR TITLE
RSPY-1036 - update the task table ICD version 1.0 draft J

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -39,3 +39,10 @@ jobs:
     permissions:
       contents: write # for apache/skywalking-eyes/header
       pull-requests: write # for apache/skywalking-eyes/header and phwt/sonarqube-quality-gate-action
+  check-tasktables:
+    runs-on: ubuntu-latest
+    name: Check tasktables (json schema)
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate tasktables
+        run: pipx run check-jsonschema --schemafile schemas/TaskTable.schema.json config/TaskTable_*.json

--- a/config/TaskTable_S1_ARD_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S1_ARD_generated_by_rs_python_v1.json
@@ -2,9 +2,9 @@
   "$schema": "./../schemas/TaskTable.schema.json",
   "tasktable": {
     "name": "s1-ard",
-    "version": 1.0,
-    "specification_version": "1.0_draft_E",
-    "update_datetime": "2025-10-03T11:00:00Z",
+    "version": "1.0.0",
+    "specification_version": "1.0_draft_J",
+    "update_datetime": "2026-04-24T15:00:00Z",
     "configuration_path": {}
   },
   "external_variables": [
@@ -395,7 +395,7 @@
       "steps": [
         {
           "unit_name": "calibration",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "cal_input": "pipeline_input"
           },
@@ -405,7 +405,7 @@
         },
         {
           "unit_name": "reference_dem",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "cal_slcs": "calibration.cal_slcs"
           },
@@ -415,7 +415,7 @@
         },
         {
           "unit_name": "reference_geometry",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "cal_slcs": "calibration.cal_slcs",
             "reference_dem": "reference_dem.reference_dem"
@@ -426,7 +426,7 @@
         },
         {
           "unit_name": "coregistration",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "cal_slcs": "calibration.cal_slcs",
             "reference_dem": "reference_dem.reference_dem",
@@ -438,7 +438,7 @@
         },
         {
           "unit_name": "geocoding",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "cslcs": "coregistration.cslcs",
             "simulation_ref": "reference_geometry.simulation_ref"
@@ -449,7 +449,7 @@
         },
         {
           "unit_name": "mosaicking",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "gslcs": "geocoding.gslcs"
           },

--- a/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
@@ -2,9 +2,9 @@
     "$schema": "./../schemas/TaskTable.schema.json",
     "tasktable": {
         "name": "s1-l0",
-        "version": 1.0,
-        "specification_version": "1.0_draftI",
-        "update_datetime": "2026-04-17T11:00:00Z",
+        "version": "1.0",
+        "specification_version": "1.0_draftJ",
+        "update_datetime": "2026-04-24T15:00:00Z",
         "configuration_path": {}
     },
     "external_variables": [
@@ -234,7 +234,7 @@
             "steps": [
                 {
                     "unit_name": "S1L0Processor",
-                    "order": 1,
+                    "step_id": 1,
                     "input_products": {
                         "S1CADUS": "pipeline_input"
                     },

--- a/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
@@ -2,9 +2,9 @@
   "$schema": "./../schemas/TaskTable.schema.json",
   "tasktable": {
     "name": "s3-l0",
-    "version": 1.0,
-    "specification_version": "1.0_draftI",
-    "update_datetime": "2026-04-17T11:00:00Z",
+    "version": "1.0",
+    "specification_version": "1.0_draftJ",
+    "update_datetime": "2026-04-24T15:00:00Z",
     "configuration_path": {}
   },
   "external_variables": [
@@ -211,7 +211,7 @@
       "steps": [
         {
           "unit_name": "S3L0Processor",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "S3ACADUS": "pipeline_input"
           },

--- a/config/TaskTable_S3_L1OLCI_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S3_L1OLCI_generated_by_rs_python_v1.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "../../schemas/TaskTable_schema_1_draft_H.json",
+  "$schema": "./../schemas/TaskTable.schema.json",
   "tasktable": {
     "name": "s3-olci-l1-eo",
-    "version": 1.32,
-    "specification_version": "1.1a",
-    "update_datetime": "2024-03-26T18:00:00Z",
+    "version": "1.32",
+    "specification_version": "1.0_draftJ",
+    "update_datetime": "2024-04-24T15:00:00Z",
     "configuration_path": {}
   },
   "external_variables": [
@@ -835,7 +835,7 @@
       "steps": [
         {
           "unit_name": "OL1",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "S03OLCL0_1": "pipeline_input",
             "S03OLCL0_2": "pipeline_input",

--- a/config/TaskTable_S3_L2OLCI_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S3_L2OLCI_generated_by_rs_python_v1.json
@@ -3,7 +3,8 @@
   "tasktable": {
     "name": "s3-olci-l2-fr",
     "version": "1.4.0",
-    "specification_version": "1.1a",
+    "specification_version": "1.0_draftJ",
+    "update_datetime": "2024-04-24T15:00:00Z",
     "configuration_path": {}
   },
   "external_variables": [
@@ -81,7 +82,7 @@
       },
       "alternatives": [
         {
-          "order": "1",
+          "order": 1,
           "timeout_seconds": 180,
           "query": {
             "name": "LatestValIntersect",
@@ -89,8 +90,8 @@
               "product_type": "S03_ADF_OLPCP",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
-              "dTa": "0",
-              "dTb": "0"
+              "dTa": 0,
+              "dTb": 0
             }
           }
         }
@@ -105,7 +106,7 @@
       },
       "alternatives": [
         {
-          "order": "1",
+          "order": 1,
           "timeout_seconds": 180,
           "query": {
             "name": "LatestValIntersect",
@@ -113,8 +114,8 @@
               "product_type": "S03_ADF_OLPPP",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
-              "dTa": "0",
-              "dTb": "0"
+              "dTa": 0,
+              "dTb": 0
             }
           }
         }
@@ -129,7 +130,7 @@
       },
       "alternatives": [
         {
-          "order": "1",
+          "order": 1,
           "timeout_seconds": 180,
           "query": {
             "name": "LatestValIntersect",
@@ -137,8 +138,8 @@
               "product_type": "S03_ADF_OLWVP",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
-              "dTa": "0",
-              "dTb": "0"
+              "dTa": 0,
+              "dTb": 0
             }
           }
         }
@@ -153,7 +154,7 @@
       },
       "alternatives": [
         {
-          "order": "1",
+          "order": 1,
           "timeout_seconds": 180,
           "query": {
             "name": "LatestValIntersect",
@@ -161,8 +162,8 @@
               "product_type": "S03_ADF_OLVGP",
               "start_datetime": "{external_variable.start_datetime}",
               "end_datetime": "{external_variable.end_datetime}",
-              "dTa": "0",
-              "dTb": "0"
+              "dTa": 0,
+              "dTb": 0
             }
           }
         }
@@ -182,8 +183,7 @@
       "store_type": "zarr",
       "store_params": {
         "consolidate": true
-      },
-      "apply_eoqc": false
+      }
     }
   ],
   "queries": [
@@ -320,7 +320,7 @@
       "steps": [
         {
           "unit_name": "OL2",
-          "order": 1,
+          "step_id": 1,
           "input_products": {
             "S03OLCEFR": "pipeline_input"
           },

--- a/schemas/TaskTable.schema.json
+++ b/schemas/TaskTable.schema.json
@@ -1,0 +1,561 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://eopf.copernicus.eu/schemas/TaskTable.schema.json",
+    "$ref": "#/$defs/Root",
+    "$defs": {
+        "Root": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string"
+                },
+                "tasktable": {
+                    "$ref": "#/$defs/Tasktable"
+                },
+                "external_variables": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "start_datetime",
+                            "end_datetime",
+                            "satellite"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "units": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Unit"
+                    }
+                },
+                "io": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Io"
+                    }
+                },
+                "queries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/QueryElement"
+                    }
+                },
+                "pipelines": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Pipeline"
+                    }
+                }
+            },
+            "required": [
+                "tasktable",
+                "external_variables",
+                "units",
+                "io",
+                "pipelines"
+            ]
+        },
+        "Io": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "folder",
+                        "filename",
+                        "regex"
+                    ]
+                },
+                "store_type": {
+                    "type": "string",
+                    "enum": [
+                        "safe",
+                        "zarr",
+                        "cadu"
+                    ]
+                },
+                "store_params": {
+                    "$ref": "#/$defs/StoreParams"
+                },
+                "opening_mode": {
+                    "type": "string",
+                    "enum": [
+                        "CREATE",
+                        "CREATE_OVERWRITE",
+                        "UPDATE"
+                    ],
+                    "default": "CREATE"
+                },
+                "multiplicity": {
+                    "type": "string",
+                    "enum": [
+                        "one_per_input",
+                        "single"
+                    ],
+                    "default": "single"
+                },
+                "alternatives": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Alternative"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "title": "Io"
+        },
+        "Alternative": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "order": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "query": {
+                    "$ref": "#/$defs/AlternativeQuery"
+                }
+            },
+            "required": [
+                "order",
+                "timeout_seconds",
+                "query"
+            ],
+            "title": "Alternative"
+        },
+        "AlternativeQuery": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "parameters": {
+                    "$ref": "#/$defs/Parameters"
+                }
+            },
+            "required": [
+                "name",
+                "parameters"
+            ],
+            "title": "AlternativeQuery"
+        },
+        "Parameters": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "product_type": {
+                    "type": "string",
+                    "maxLength": 16,
+                    "pattern": "^[^\\s]+$"
+                },
+                "start_datetime": {
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "end_datetime": {
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "dTa": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "dTb": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "satellite": {
+                    "type": "string",
+                    "maxLength": 128
+                }
+            },
+            "title": "Parameters"
+        },
+        "StoreParams": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "consolidate": {
+                    "type": "boolean"
+                },
+                "regex": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "multiplicity": {
+                    "type": "string",
+                    "enum": [
+                        "more_than_one",
+                        "exactly_one"
+                    ]
+                }
+            },
+            "title": "StoreParams"
+        },
+        "Pipeline": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Step"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "description",
+                "steps"
+            ],
+            "title": "Pipeline"
+        },
+        "Step": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "unit_name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "step_id": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "input_products": {
+                    "$ref": "#/$defs/InputProducts"
+                },
+                "output_products": {
+                    "$ref": "#/$defs/OutputProducts"
+                },
+                "parameters": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "unit_name",
+                "step_id",
+                "input_products",
+                "output_products"
+            ],
+            "title": "Step"
+        },
+        "InputProducts": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "anyOf": [
+                    {
+                        "const": "pipeline_input"
+                    },
+                    {
+                        "pattern": "^[^\\.]+\\.[^\\.]+$"
+                    }
+                ]
+            },
+            "title": "InputProducts"
+        },
+        "OutputProducts": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "enum": [
+                    "pipeline_output",
+                    "pipeline_internal"
+                ]
+            },
+            "title": "OutputProducts"
+        },
+        "QueryElement": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "product_type",
+                            "start_datetime",
+                            "end_datetime",
+                            "dTa",
+                            "dTb",
+                            "satellite"
+                        ]
+                    },
+                    "uniqueItems": true,
+                    "minItems": 0,
+                    "maxItems": 6
+                },
+                "stac": {
+                    "$ref": "#/$defs/Stac"
+                }
+            },
+            "required": [
+                "name",
+                "parameters",
+                "stac"
+            ],
+            "title": "QueryElement"
+        },
+        "Stac": {
+            "type": "object",
+            "title": "Stac"
+        },
+        "Tasktable": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "version": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "specification_version": {
+                    "type": "string",
+                    "maxLength": 16,
+                    "pattern": "^[^\\s]+$"
+                },
+                "update_datetime": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "configuration_path": {
+                    "$ref": "#/$defs/ConfigurationPath"
+                }
+            },
+            "required": [
+                "name",
+                "version",
+                "specification_version",
+                "update_datetime"
+            ],
+            "title": "Tasktable"
+        },
+        "ConfigurationPath": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "processor": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9_./]+$"
+                    }
+                },
+                "eoqc": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9_./]+$"
+                }
+            },
+            "title": "ConfigurationPath"
+        },
+        "Unit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "module": {
+                    "type": "string",
+                    "maxLength": 164,
+                    "pattern": "^[a-zA-Z0-9_./]+$"
+                },
+                "resources_min": {
+                    "$ref": "#/$defs/ResourcesMin"
+                },
+                "input_products": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Input"
+                    }
+                },
+                "input_adfs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Input"
+                    }
+                },
+                "output_products": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/OutputProduct"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "module",
+                "resources_min",
+                "input_products",
+                "output_products"
+            ],
+            "title": "Unit"
+        },
+        "Input": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "mode": {
+                    "$ref": "#/$defs/Mode"
+                },
+                "mandatory": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name",
+                "mandatory"
+            ],
+            "title": "Input"
+        },
+        "OutputProduct": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/NonEmptyIdentifier"
+                },
+                "mode": {
+                    "$ref": "#/$defs/Mode"
+                },
+                "mandatory": {
+                    "type": "boolean"
+                },
+                "final_product": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "regex": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "apply_eoqc": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "required": [
+                "name",
+                "mandatory"
+            ],
+            "title": "OutputProduct"
+        },
+        "ResourcesMin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dask": {
+                    "$ref": "#/$defs/Dask"
+                },
+                "disk": {
+                    "$ref": "#/$defs/Disk"
+                }
+            },
+            "required": [
+                "dask",
+                "disk"
+            ],
+            "title": "ResourcesMin"
+        },
+        "Dask": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "worker_cpu": {
+                    "$ref": "#/$defs/StrictlyPositiveNumber"
+                },
+                "worker_ram": {
+                    "$ref": "#/$defs/DigitalDataSize"
+                },
+                "worker_thread_count": {
+                    "$ref": "#/$defs/StrictlyPositiveInteger"
+                },
+                "worker_count": {
+                    "$ref": "#/$defs/StrictlyPositiveInteger"
+                }
+            },
+            "required": [
+                "worker_cpu",
+                "worker_ram",
+                "worker_thread_count",
+                "worker_count"
+            ],
+            "title": "Dask"
+        },
+        "Disk": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "size_per_worker": {
+                    "$ref": "#/$defs/DigitalDataSize"
+                },
+                "size_temporary_share": {
+                    "$ref": "#/$defs/DigitalDataSize"
+                }
+            },
+            "required": [
+                "size_per_worker"
+            ],
+            "title": "Disk"
+        },
+        "Mode": {
+            "type": "string",
+            "enum": [
+                "nrt",
+                "ntc",
+                "reprocessing",
+                "subs",
+                "always"
+            ],
+            "default": "always",
+            "title": "Mode"
+        },
+        "NonEmptyIdentifier": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[^\\s]+$"
+        },
+        "DigitalDataSize": {
+            "type": "string",
+            "pattern": "^[1-9][0-9]*\\s?(MB|GB|TB)$"
+        },
+        "StrictlyPositiveInteger": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+        },
+        "StrictlyPositiveNumber": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        }
+    }
+}


### PR DESCRIPTION
Update to the task table ICD draft J and add json schema validation of task tables in the CI.

I've changed the following in the tasktable json schema:
- updated to JSON Schema from [draft7](https://json-schema.org/draft-07) to [2020-12](https://json-schema.org/draft/2020-12)
- changed `version` from `number` to non-empty string as per ESA request
- defined new types to reduce copy/paste:
  - `NonEmptyIdentifier`
  - `DigitalDataSize`
  - `StrictlyPositiveInteger`
  - `StrictlyPositiveNumber`

Pull requests:
- https://github.com/RS-PYTHON/rs-client-libraries/pull/286
- https://github.com/RS-PYTHON/rs-dpr-service/pull/113