### PR TITLE
Fix: ADFS input names in uppercase in tasktables

### DIFF
--- a/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S1_L0_generated_by_rs_python_v1.json
@@ -36,17 +36,17 @@
             ],
             "input_adfs": [
                 {
-                    "name": "OSF",
+                    "name": "osf",
                     "mode": "always",
                     "mandatory": false
                 },
                 {
-                    "name": "FRO",
+                    "name": "fro",
                     "mode": "always",
                     "mandatory": false
                 },
                 {
-                    "name": "FPO",
+                    "name": "fpo",
                     "mode": "always",
                     "mandatory": false
                 }
@@ -86,7 +86,7 @@
             "store_type": "cadu"
         },
         {
-            "name": "OSF",
+            "name": "osf",
             "type": "filename",
             "store_type": "safe",
             "alternatives": [
@@ -108,7 +108,7 @@
             ]
         },
         {
-            "name": "FRO",
+            "name": "fro",
             "type": "filename",
             "store_type": "safe",
             "alternatives": [
@@ -130,7 +130,7 @@
             ]
         },
         {
-            "name": "FPO",
+            "name": "fpo",
             "type": "filename",
             "store_type": "safe",
             "alternatives": [

--- a/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
+++ b/config/TaskTable_S3_L0_generated_by_rs_python_v1.json
@@ -36,12 +36,12 @@
       ],
       "input_adfs": [
         {
-          "name": "OSF",
+          "name": "osf",
           "mode": "always",
           "mandatory": false
         },
         {
-          "name": "FRO",
+          "name": "fro",
           "mode": "always",
           "mandatory": false
         }
@@ -70,7 +70,7 @@
       "store_type": "cadu"
     },
     {
-      "name": "OSF",
+      "name": "osf",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "name": "FRO",
+      "name": "fro",
       "type": "filename",
       "store_type": "safe",
       "alternatives": [

--- a/config/tasktable.json
+++ b/config/tasktable.json
@@ -35,12 +35,12 @@
             ],
             "input_adfs": [
                 {
-                    "name": "OSF",
+                    "name": "osf",
                     "mode": "always",
                     "mandatory": false
                 },
                 {
-                    "name": "FRO",
+                    "name": "fro",
                     "mode": "always",
                     "mandatory": false
                 }
@@ -62,7 +62,7 @@
             "store_type": "cadu"
         },
         {
-            "name": "OSF",
+            "name": "osf",
             "type": "filename",
             "store_type": "safe",
             "alternatives": [
@@ -83,7 +83,7 @@
             ]
         },
         {
-            "name": "FRO",
+            "name": "fro",
             "type": "filename",
             "store_type": "safe",
             "alternatives": [


### PR DESCRIPTION
Fix to have ADFS input names in lowercase in the tasktables, instead of uppercase.