### PR TITLE
RSPY-1084 - Write secrets.json config file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ skips = ['*/*.py']
 
 [tool.bandit]
 skips = ['B603', 'B607', 'B404']
+assert_nosec = false
 
 
 [tool.poetry.requires-plugins]

--- a/rs_dpr_service/dask/call_dask.py
+++ b/rs_dpr_service/dask/call_dask.py
@@ -497,6 +497,11 @@ class ProcessorCaller:
             with open(self.log_path, "w", encoding="utf-8") as log_file:
                 log_file.write(message)
 
+            # Get secret configuration file (optional)
+            secret_conf_files = self.payload_contents.get("secret")
+            if secret_conf_files:
+                self.write_secret_conf_files(secret_conf_files, payload_contents, payload_file)
+
             # Get logging configuration file
             # log_conf_file = self.payload_contents.get("logging")
 
@@ -511,6 +516,69 @@ class ProcessorCaller:
         #         log_conf_contents["disable_existing_loggers"] = False
         #     with open(log_conf_file, "w+", encoding="utf-8") as opened:
         #         opened.write(yaml.safe_dump(log_conf_contents))
+
+    @staticmethod
+    def _collect_storage_options(payload_contents: dict) -> list[dict]:
+        io = payload_contents.get("I/O", payload_contents.get("io", {}))
+        result = []
+        for product in io.get("input_products", []):
+            if so := product.get("reader_params", product.get("store_params", {})).get("storage_options"):
+                result.append(so)
+        for product in io.get("output_products", []):
+            if so := product.get("writer_params", product.get("store_params", {})).get("storage_options"):
+                result.append(so)
+        for adf in io.get("adfs", []):
+            if so := adf.get("adf_params", adf.get("store_params", {})).get("storage_options"):
+                result.append(so)
+        return result
+
+    def write_secret_conf_files(self, secret_conf_files: list[str], payload_contents: dict, payload_file: str):
+        """
+        Write the external secret json config file(s) from the ones provided in the payload.
+        """
+        if len(secret_conf_files) > 1:
+            logger.error("A single secret json config file is expected for now")
+            return
+        secret_conf_file = osp.join(osp.dirname(payload_file), secret_conf_files[0])
+
+        all_storage_options = self._collect_storage_options(payload_contents)
+        if not all_storage_options:
+            logger.warning("No storage_options found in payload, skipping secret conf file writing")
+            return
+
+        unique_credentials = {
+            (
+                so.get("key"),
+                so.get("secret"),
+                so.get("client_kwargs", {}).get("endpoint_url"),
+                so.get("client_kwargs", {}).get("region_name"),
+            )
+            for so in all_storage_options
+        }
+
+        if len(unique_credentials) > 1:
+            logger.error(
+                "Multiple different credential sets found in payload storage_options, "
+                "cannot write a single secret conf file",
+            )
+            return
+
+        key, secret, endpoint_url, region_name = unique_credentials.pop()
+
+        with open(secret_conf_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "s3": {
+                        "key": key,
+                        "secret": secret,
+                        "client_kwargs": {"endpoint_url": endpoint_url, "region_name": region_name},
+                    },
+                },
+                f,
+                indent=2,
+            )
+
+        logger.info("Secret configuration file written: %s", secret_conf_file)
 
     def write_dask_context(self, payload_contents: dict):
         """

--- a/tests/test_dask_call_dask.py
+++ b/tests/test_dask_call_dask.py
@@ -426,3 +426,168 @@ def test_processor_caller_run_processor_returns_mockup_finalize_value(mocker):
     caller.init.assert_called_once_with()
     caller.trigger.assert_called_once_with()
     assert result == [{"status": "successful"}]
+
+
+# ---- _collect_storage_options ----
+
+
+def test_collect_storage_options_returns_empty_when_no_io_section():
+    """Returns an empty list when the payload has no I/O section."""
+    assert not call_dask.ProcessorCaller._collect_storage_options({})  # pylint: disable=protected-access
+
+
+def test_collect_storage_options_gathers_all_sections():
+    """Collects storage_options from input_products, output_products, and adfs."""
+    so_in = {"key": "k1", "secret": "s1"}  # nosec B105
+    so_out = {"key": "k2", "secret": "s2"}  # nosec B105
+    so_adf = {"key": "k3", "secret": "s3"}  # nosec B105
+    payload = {
+        "I/O": {
+            "input_products": [{"reader_params": {"storage_options": so_in}}],
+            "output_products": [{"writer_params": {"storage_options": so_out}}],
+            "adfs": [{"adf_params": {"storage_options": so_adf}}],
+        },
+    }
+    result = call_dask.ProcessorCaller._collect_storage_options(payload)  # pylint: disable=protected-access
+    assert result == [so_in, so_out, so_adf]
+
+
+def test_collect_storage_options_skips_items_without_storage_options():
+    """Items whose params dict has no storage_options key are excluded."""
+    payload: dict[str, object] = {
+        "I/O": {
+            "input_products": [{"reader_params": {}}],
+            "output_products": [{"writer_params": {}}],
+            "adfs": [{"adf_params": {}}],
+        },
+    }
+    assert not call_dask.ProcessorCaller._collect_storage_options(payload)  # pylint: disable=protected-access
+
+
+def test_collect_storage_options_falls_back_to_store_params():
+    """Uses store_params when reader_params / writer_params / adf_params are absent."""
+    so = {"key": "k"}
+    payload = {
+        "I/O": {
+            "input_products": [{"store_params": {"storage_options": so}}],
+            "output_products": [{"store_params": {"storage_options": so}}],
+            "adfs": [{"store_params": {"storage_options": so}}],
+        },
+    }
+    result = call_dask.ProcessorCaller._collect_storage_options(payload)  # pylint: disable=protected-access
+    assert result == [so, so, so]
+
+
+def test_collect_storage_options_uses_lowercase_io_key_fallback():
+    """Falls back to the 'io' key when 'I/O' is absent."""
+    so = {"key": "k"}
+    payload = {"io": {"input_products": [{"reader_params": {"storage_options": so}}]}}
+    result = call_dask.ProcessorCaller._collect_storage_options(payload)  # pylint: disable=protected-access
+    assert result == [so]
+
+
+# ---- write_secret_conf_files ----
+
+
+def test_write_secret_conf_files_errors_on_multiple_files(mocker, tmp_path):
+    """Logs an error and writes nothing when more than one secret file is requested."""
+    caller = _make_processor_caller(mocker)
+    error_log = mocker.patch("rs_dpr_service.dask.call_dask.logger.error")
+
+    caller.write_secret_conf_files(["a.json", "b.json"], {}, str(tmp_path / "payload.yaml"))
+
+    error_log.assert_called_once()
+    assert not list(tmp_path.iterdir())
+
+
+def test_write_secret_conf_files_warns_when_no_storage_options(mocker, tmp_path):
+    """Logs a warning and writes nothing when the payload contains no storage_options."""
+    caller = _make_processor_caller(mocker)
+    warn_log = mocker.patch("rs_dpr_service.dask.call_dask.logger.warning")
+
+    caller.write_secret_conf_files(["secrets.json"], {}, str(tmp_path / "payload.yaml"))
+
+    warn_log.assert_called_once()
+    assert not (tmp_path / "secrets.json").exists()
+
+
+def test_write_secret_conf_files_errors_on_multiple_credential_sets(mocker, tmp_path):
+    """Logs an error and writes nothing when differing credentials are found across products."""
+    caller = _make_processor_caller(mocker)
+    payload = {
+        "I/O": {
+            "input_products": [
+                {
+                    "reader_params": {
+                        "storage_options": {
+                            "key": "k1",
+                            "secret": "s1",  # nosec B105
+                            "client_kwargs": {"endpoint_url": "u1", "region_name": "r1"},
+                        },
+                    },
+                },
+                {
+                    "reader_params": {
+                        "storage_options": {
+                            "key": "k2",
+                            "secret": "s2",  # nosec B105
+                            "client_kwargs": {"endpoint_url": "u2", "region_name": "r2"},
+                        },
+                    },
+                },
+            ],
+        },
+    }
+    error_log = mocker.patch("rs_dpr_service.dask.call_dask.logger.error")
+
+    caller.write_secret_conf_files(["secrets.json"], payload, str(tmp_path / "payload.yaml"))
+
+    error_log.assert_called_once()
+    assert not (tmp_path / "secrets.json").exists()
+
+
+def test_write_secret_conf_files_nominal(mocker, tmp_path):
+    """Writes secrets.json with the correct structure when all credentials are identical."""
+    caller = _make_processor_caller(mocker)
+    creds = {
+        "key": "mykey",
+        "secret": "mysecret",  # nosec B105
+        "client_kwargs": {"endpoint_url": "https://s3.test", "region_name": "eu-west"},
+    }
+    payload = {
+        "I/O": {
+            "input_products": [{"reader_params": {"storage_options": creds}}],
+            "output_products": [{"writer_params": {"storage_options": creds}}],
+            "adfs": [{"adf_params": {"storage_options": creds}}],
+        },
+    }
+
+    caller.write_secret_conf_files(["secrets.json"], payload, str(tmp_path / "payload.yaml"))
+
+    secrets_path = tmp_path / "secrets.json"
+    assert secrets_path.exists()
+    assert json.loads(secrets_path.read_text(encoding="utf-8")) == {
+        "s3": {
+            "key": "mykey",
+            "secret": "mysecret",  # nosec B105
+            "client_kwargs": {"endpoint_url": "https://s3.test", "region_name": "eu-west"},
+        },
+    }
+
+
+def test_write_secret_conf_files_written_next_to_payload(mocker, tmp_path):
+    """Secrets file is created in the payload directory, not the process cwd."""
+    caller = _make_processor_caller(mocker)
+    payload_dir = tmp_path / "subdir"
+    payload_dir.mkdir()
+    creds = {
+        "key": "k",
+        "secret": "s",  # nosec B105
+        "client_kwargs": {"endpoint_url": "u", "region_name": "r"},
+    }
+    payload = {"I/O": {"input_products": [{"reader_params": {"storage_options": creds}}]}}
+
+    caller.write_secret_conf_files(["secrets.json"], payload, str(payload_dir / "payload.yaml"))
+
+    assert (payload_dir / "secrets.json").exists()
+    assert not (tmp_path / "secrets.json").exists()


### PR DESCRIPTION
Configure shared temporary S3 folder between processing Dask workers

Pull requests:
- https://github.com/RS-PYTHON/rs-client-libraries/pull/333
- https://github.com/RS-PYTHON/rs-dpr-service/pull/130