### PR TITLE
Configure the available processors in DPR service helm chart

### DIFF
--- a/rs_dpr_service/main.py
+++ b/rs_dpr_service/main.py
@@ -118,6 +118,31 @@ HandleExceptionsMiddleware.disable_default_exception_handler(app)
 app.add_middleware(HealthMiddleware)
 
 
+def get_enabled_processors() -> set[str] | None:
+    """Return the desired processors. These are set in DPR_ENABLED_PROCESSORS by deployment in rs-helm."""
+    raw = os.environ.get("DPR_ENABLED_PROCESSORS")
+    if raw is None:
+        return None
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def filter_enabled_resources(config: dict) -> dict:
+    """Return the usual list of processors in local mode, and a specific one on cluster."""
+
+    enabled = get_enabled_processors()
+
+    # For localmode use the default configuration
+    if enabled is None:
+        return config
+
+    config["resources"] = {
+        resource_name: resource_config
+        for resource_name, resource_config in config.get("resources", {}).items()
+        if resource_config.get("processor", {}).get("name") in enabled
+    }
+    return config
+
+
 def get_config_path() -> pathlib.Path:
     """Return the pygeoapi configuration path and set the PYGEOAPI_CONFIG env var accordingly."""
     path = pathlib.Path(__file__).parent.parent / "config" / "geoapi.yaml"
@@ -135,7 +160,8 @@ def get_config_contents() -> dict:
         contents = Template(contents).substitute(os.environ)
 
         # Parse contents as yaml
-        return yaml.safe_load(contents)
+        config = yaml.safe_load(contents)
+        return filter_enabled_resources(config)
 
 
 def init_pygeoapi() -> API:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,6 +21,7 @@ NOTE: COPY-PASTED FROM pytest_common_tests.py in RS-SERVER.
 import copy
 import json
 from datetime import datetime
+from importlib import reload
 from unittest.mock import AsyncMock
 
 import pytest
@@ -475,3 +476,27 @@ def test_delete_job_endpoint_returns_404_for_unknown_job(client, mocker):
     assert response.status_code == 404
     assert response.json()["detail"] == "Job with ID unknown-job not found"
     cancel_event.set.assert_not_called()
+
+
+def test_variable_processors(client, mocker, monkeypatch):
+    """Test that only ceertain processors are exposed."""
+    client.app.extra["process_manager"] = mocker.Mock()
+
+    monkeypatch.setenv(
+        "DPR_ENABLED_PROCESSORS",
+        "conv_safe_zarr,s1_l0,s3_l0",
+    )
+
+    reload(main_module)
+    response = client.get("/dpr/processes")
+    assert response.status_code == 200
+
+    processes = {p["id"] for p in response.json()["processes"]}
+
+    assert processes == {
+        "conv_safe_zarr",
+        "s1_l0",
+        "s3_l0",
+    }
+
+    assert "mockup" not in processes


### PR DESCRIPTION
RS DPR service shall be able to take the list of processors enabled from the helm chart configuration. By default it shall include everything except the mockup. We should be able to configure in the helm chart the list of processors we want (for example, just the S1 processors, just the S3 processors, etc.)